### PR TITLE
add an example `docker-compose.yml` for Docker Compose version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ It's based on :
 * or [edyan/php:7.2](https://github.com/edyan/docker-php/tree/master/7.2) image (stretch stable).
 
 It's made for development purposes. You need to find the right version for your project.
-Use 5.6 for PHP 5.6 projects and 7.2 for PHP 7.x projects. Just make sure you have the 
-`mongodb` extension enabled (v1.5) on your main PHP container.  
+Use 5.6 for PHP 5.6 projects and 7.2 for PHP 7.x projects. Just make sure you have the
+`mongodb` extension enabled (v1.5) on your main PHP container.
 
 To use it in an integrated environment, try [Stakkr](https://github.com/stakkr-org/stakkr)
 
 
 ## Example
+
 To make it work, you need to link it to an existing PHP environment. Example via `docker-compose.yml` :
+
+The Docker Compose configuration is different for Compose versions 2 and 3:
 
 ```yaml
 version: '2'
@@ -41,9 +44,37 @@ services:
       - "8000:80"
     volumes:
       - ./src:/var/www
-
 ```
 
+The `volumes_from` is no longer supported in the Docker Compose version 3 syntax. We have to define a volume for *xhgui* in the global section of the config file and reference it in each of the services:
+
+```yaml
+version: '3'
+
+volumes:
+  xhgui:
+
+services:
+  xhgui:
+    image: edyan/xhgui:php7.2
+    # I need to access xhgui
+    ports:
+      - "9000:80"
+    volumes:
+      - ./xhgui-config.php:/usr/local/src/xhgui/config/config.php
+      - xhgui:/usr/local/src
+  php:
+    hostname: php
+    command: /usr/bin/php -S 0.0.0.0:80 -t /var/www
+    image: edyan/php:7.2 # That image contains mongodb extension from PECL
+    # To have the new mounted volumes as well as the default volumes of xhgui (its source code)
+    ports:
+      - "8000:80"
+    volumes:
+      - ./src:/var/www
+      - xhgui:/usr/local/src
+      - ./.config/xhgui/config.php:/usr/local/src/xhgui/config/config.php
+```
 
 As seen above, you need to mount your own configuration file that connects to the **right** mongodb server. The `xhgui-config.php` file, in our case (see the [official xhgui repo](https://github.com/perftools/xhgui)), will contain (*note the db.host*):
 ```php
@@ -88,7 +119,7 @@ test_xhgui();
 ```
 
 Finally, launch the environment with : `docker-compose up --force-recreate`.
-Then call _http://localhost:8000/index.php_ in your browser and  get reports 
+Then call _http://localhost:8000/index.php_ in your browser and  get reports
 from _http://localhost:9000_.
 
 
@@ -121,9 +152,9 @@ See the [documentation](https://github.com/edyan/docker-php#custom-phpini-direct
 
 
 ## Quick Test
-A `docker-compose` file is available to do some tests: 
+A `docker-compose` file is available to do some tests:
 ```bash
-$ docker-compose -f docker-compose.sample.yml up --force-recreate -d 
+$ docker-compose -f docker-compose.sample.yml up --force-recreate -d
 # Enter the php container
 $ docker-compose -f docker-compose.sample.yml exec php bash
 # Create a file
@@ -135,7 +166,7 @@ $ echo '<?php putenv("XHGUI_MONGO_HOST=mongodb://xhgui"); require_once("/usr/loc
 Now open http://localhost:8000/index.php to read the new file created.
 Then http://localhost:9000 to see the report.
 
-Clean : 
+Clean :
 ```bash
-$ docker-compose -f docker-compose.sample.yml down 
+$ docker-compose -f docker-compose.sample.yml down
 ```


### PR DESCRIPTION
Compose version 3 no longer supports the `volumes_from` option. I've added an example `docker-compose.yml` which shows a work around.